### PR TITLE
Removing trailing commas from package.json template

### DIFF
--- a/app/templates/package.json
+++ b/app/templates/package.json
@@ -25,7 +25,7 @@
     "minor": "npm version minor && npm publish",
     "major": "npm version major && npm publish",
     "postpublish": "git push origin master --follow-tags",
-    "toc": "doctoc --github --title \"# Changelog\" CHANGELOG.md",
+    "toc": "doctoc --github --title \"# Changelog\" CHANGELOG.md"
   },
   "repository": {
     "type": "git",
@@ -52,7 +52,7 @@
     "rimraf": "*",
     "dependency-check": "*",
     "watch": "*",
-    "doctoc": "*",
+    "doctoc": "*"
   },
   "dependencies": {
     "babel-runtime": "*"


### PR DESCRIPTION
Was getting some errors from `npm install` (npm version 2.10.1) resulting from trailing commas in the `package.json` template. This PR removes them. Not sure if it's an issue on my end or with npm. If so, just let me know. Thanks!