### PR TITLE
Fixed option for centering README. Added stable node to travisci config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,6 @@ node_js:
   - "0.12"
   - "iojs-1"
   - "iojs-2"
+  - "stable"
 after_script:
   - npm run coveralls

--- a/app/index.js
+++ b/app/index.js
@@ -66,7 +66,7 @@ module.exports = Yeoman.generators.Base.extend({
         this.humanizedWebsite = humanize(props.website)
 
         this.template(props.center
-          ? "README.md" : "README-2.md", "README.md")
+          ? "README-2.md" : "README.md", "README.md")
         this.template("package.json")
         this.template("LICENSE")
         this.template("CHANGELOG.md")

--- a/app/templates/travis.yml
+++ b/app/templates/travis.yml
@@ -5,5 +5,6 @@ node_js:
   - '0.12'
   - 'iojs-1'
   - 'iojs-2'
+  - 'stable'
 after_script:
   - npm run coveralls


### PR DESCRIPTION
Travisci 'stable' version option for node should now be 4.0. Left in
existing versions for broadness.

The support for 4.0 isn't reflected in travisci docs at time of writing. Using a [yo PR](https://github.com/yeoman/yo/blob/6fed0e0c3cee6f6409fa2a32c7c225165ffd1c4e/.travis.yml) as reference to correctness.