### PR TITLE
update nodejs versions to actual ones

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.10"
-  - "0.11"
-  - "0.12"
-  - "iojs-1"
-  - "iojs-2"
-  - "stable"
+  - v5
+  - v4
+  - '0.12'
+  - '0.10'
 after_script:
-  - npm run coveralls
+  - 'npm run coveralls'


### PR DESCRIPTION
there is no need to test current projects on iojs and deprecated unstable versions