### PR TITLE
remove redundant babel deps

### DIFF
--- a/app/templates/package.json
+++ b/app/templates/package.json
@@ -44,7 +44,6 @@
   "devDependencies": {
     "eslint": "*",
     "babel-eslint": "*",
-    "babel": "*",
     "coveralls": "*",
     "isparta": "*",
     "tape": "*",
@@ -53,8 +52,5 @@
     "dependency-check": "*",
     "watch": "*",
     "doctoc": "*"
-  },
-  "dependencies": {
-    "babel-runtime": "*"
   }
 }


### PR DESCRIPTION
relevand babel deps are installing from generator-babel, and current ones create conflicts about it. I fixed that it relevant pr, but gp didnt work for me that time, and i didnt notice it. sorry